### PR TITLE
Fix Caddy install

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add tini git \
     && apk --no-cache add --virtual devs tar curl && rm -rf /var/cache/apk/*
 
 #Install Caddy Server, and All Middleware
-RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jsonp,jwt,mailout,prometheus,realip,search,upload" \
+RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=git,hugo,ipfilter,jwt,mailout,prometheus,realip,search" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 #Remove build devs


### PR DESCRIPTION
Hi,

This PR fixes the installation of caddy.

The download link returns a 400 with an error message about the  following features not being recognised:
- cors
- jsonp
- upload

```
$ curl -i "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jsonp,jwt,mailout,prometheus,realip,search,upload"
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Location
Content-Length: 23
Content-Security-Policy: style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/ https://maxcdn.bootstrapcdn.com; script-src https://www.google-analytics 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; img-src 'self' data: https:; font-src 'self' https: data: blob:; media-src 'self' https: data: blob:; connect-src 'self' https:; object-src 'none';
Content-Type: text/plain; charset=utf-8
Date: Mon, 08 Aug 2016 05:16:07 GMT
Server: Caddy
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

unknown feature 'cors'
```
