### PR TITLE
Fixing Caddy download URL

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add tini git \
     && apk --no-cache add --virtual devs tar curl && rm -rf /var/cache/apk/*
 
 #Install Caddy Server, and All Middleware
-RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jsonp,jwt,mailout,prometheus,realip,search,upload" \
+RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jwt,mailout,prometheus,realip,search,upload" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 #Remove build devs


### PR DESCRIPTION
The Caddy download URL in the Dockerfile is no longer valid because Caddy does not recognize "jsonp" feature. Because of this, the docker-compose build command fails on the Caddy download step. I removed the jsonp feature from the URL and it downloads and builds correctly. 

Before:  

```
Step 3 : RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jsonp,jwt,mailout,prometheus,realip,search,upload"     | tar --no-same-owner -C /usr/bin/ -xz caddy
 ---> Running in 6f6ef3657dec
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    24  100    24    0     0     65      0 --:--:-- --:--:-- --:--:--    73
gzip: invalid magic
tar: Child returned status 1
tar: Error is not recoverable: exiting now
ERROR: Service 'caddy' failed to build: The command '/bin/sh -c curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jsonp,jwt,mailout,prometheus,realip,search,upload"     | tar --no-same-owner -C /usr/bin/ -xz caddy' returned a non-zero code: 2
```

After:

```
Step 3 : RUN curl "https://caddyserver.com/download/build?os=linux&arch=amd64&features=cors,git,hugo,ipfilter,jwt,mailout,prometheus,realip,search,upload"     | tar --no-same-owner -C /usr/bin/ -xz caddy
 ---> Running in 27698a0bd1f1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 6585k    0 6585k    0     0  5434k      0 --:--:--  0:00:01 --:--:-- 5633k
 ---> 27e57039d8a9
Removing intermediate container 27698a0bd1f1

```
