### PR TITLE
Update API

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,20 @@
-FROM alpine:latest
+FROM golang:1.8.1
 
 EXPOSE 11015
 
-RUN apk --update add curl && rm -fr /var/cache/apk/*
-RUN curl -Lo /usr/bin/api-server https://github.com/lair-framework/api-server/releases/download/v1.1.0/api-server_linux_amd64 \
-     && chmod +x /usr/bin/api-server
-
+RUN go get -v github.com/lair-framework/api-server
+ADD plugins /plugins
+WORKDIR /plugins
+RUN rm .keep
+RUN for file in *.go;                                         \
+        do                                                    \
+                echo "Making so for $file"  &&                \
+                so=$(echo $file | sed 's/\.go$/\.so/g') &&    \
+                go build -v -buildmode=plugin -o $so $file && \
+                rm $file ;                                    \
+        done
+WORKDIR /root
+ENV TRANSFORM_DIR=/plugins
 ENV MONGO_URL=mongodb://lairdb:27017/lair
 ENV API_LISTENER=0.0.0.0:11015
-
-CMD /usr/bin/api-server
+CMD api-server


### PR DESCRIPTION
Updated lair-api to now support go plugins. However, in
order to use plugins the main app and plugins need to be compiled on the
same host. We now use golang:1.8.1 image and build the api-server and
any plugin in the plugins directory.

All the user has to do to use plugins, is drop the plugin .go file into the plugins directory. 