### PR TITLE
pinned meteor version to 1.7.0.5

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root/app
 RUN apt-get update
 RUN apt-get install -y bsdtar && ln -sf $(which bsdtar) $(which tar)
 
-RUN curl https://install.meteor.com/ | sh
+RUN curl https://install.meteor.com/?release=1.7.0.5 | sh
 RUN curl -SLO "https://github.com/lair-framework/lair/releases/download/v2.5.0/lair-v2.5.0-linux-amd64.tar.gz" \
     && tar -zxf lair-v2.5.0-linux-amd64.tar.gz \
     && cd bundle/programs/server \


### PR DESCRIPTION
I was able to resolve #20 by pinning the meteor version to 1.7.0.5, which was the last version known to run with [the most recent commit](https://github.com/lair-framework/lair-docker/commit/d94fe1643bd13b1d63600a6108d3da4a012af864).
Tested with Kali rolling and
```Docker version 19.03.8, build afacb8b7f0```
```docker-compose version 1.25.0, build unknown```