### PR TITLE
fixed caddy download and meteor version

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y bsdtar && ln -sf $(which bsdtar) $(which tar)
 
 # from https://github.com/lair-framework/lair-docker/pull/21/commits/b174836f8a882cca57036cdc8bce30854316f24b
-RUN curl RUN curl https://install.meteor.com/?release=1.7.0.5 | sh
+RUN curl https://install.meteor.com/?release=1.7.0.5 | sh
 RUN curl -SLO "https://github.com/lair-framework/lair/releases/download/v2.5.0/lair-v2.5.0-linux-amd64.tar.gz" \
     && tar -zxf lair-v2.5.0-linux-amd64.tar.gz \
     && cd bundle/programs/server \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /root/app
 RUN apt-get update
 RUN apt-get install -y bsdtar && ln -sf $(which bsdtar) $(which tar)
 
-RUN curl https://install.meteor.com/ | sh
+# from https://github.com/lair-framework/lair-docker/pull/21/commits/b174836f8a882cca57036cdc8bce30854316f24b
+RUN curl RUN curl https://install.meteor.com/?release=1.7.0.5 | sh
 RUN curl -SLO "https://github.com/lair-framework/lair/releases/download/v2.5.0/lair-v2.5.0-linux-amd64.tar.gz" \
     && tar -zxf lair-v2.5.0-linux-amd64.tar.gz \
     && cd bundle/programs/server \

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,6 +5,7 @@ RUN apk --no-cache add tini git \
 
 #Install Caddy Server, and All Middleware
 RUN curl https://caddyserver.com/download/linux/amd64?license=personal | tar --no-same-owner -C /usr/bin/ -xz caddy
+RUN curl -L https://github.com/caddyserver/caddy/releases/download/v1.0.4/caddy_v1.0.4_linux_amd64.tar.gz | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 #Remove build devs
 RUN apk del devs

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add tini git \
     && apk --no-cache add --virtual devs tar curl && rm -rf /var/cache/apk/*
 
 #Install Caddy Server, and All Middleware
-RUN curl https://caddyserver.com/download/linux/amd64?license=personal | tar --no-same-owner -C /usr/bin/ -xz caddy
+# RUN curl https://caddyserver.com/download/linux/amd64?license=personal | tar --no-same-owner -C /usr/bin/ -xz caddy
 RUN curl -L https://github.com/caddyserver/caddy/releases/download/v1.0.4/caddy_v1.0.4_linux_amd64.tar.gz | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 #Remove build devs


### PR DESCRIPTION
Meteor version as per https://github.com/lair-framework/lair-docker/pull/21 (sorry, quicker to copy-paste your changes than to remember how to merge across forks...).